### PR TITLE
Fix domain grouping for sites with country-code TLDs (e.g., .co.uk) and more

### DIFF
--- a/background.js
+++ b/background.js
@@ -50,8 +50,10 @@ function genGroupName(url) {
 }
 
 function formatGroupName(domain) {
-    // Remove .com and capitalize the first letter
-    const name = domain.replace(/\.com$/, '');
+    // Remove common domain extensions using a regular expression
+    const name = domain.replace(/\.(com|net|org|io|co|edu|gov|mil|biz|info|mobi|name|aero|asia|jobs|museum|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cu|cv|cx|cy|cz|de|dj|dk|dm|do|dz|ec|ee|eg|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|sk|sl|sm|sn|so|sr|st|su|sv|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|za|zm|zw)$/i, '');
+    
+    // Capitalize the first letter
     return name.charAt(0).toUpperCase() + name.slice(1);
 }
 

--- a/background.js
+++ b/background.js
@@ -40,21 +40,24 @@ function genGroupName(url) {
         }
     }
 
-    // Extract main domain (e.g., 'docs.google.com' → 'google.com')
     const parts = hostname.split('.');
-    if (parts.length > 2) {
-        // Remove subdomains and 'www' prefix
+    // Remove 'www' prefix if present
+    if (parts[0] === 'www') parts.shift();
+    
+    // Handle country-code TLDs (e.g., .co.uk, .com.br)
+    if (parts.length >= 3 && parts[parts.length - 1].length === 2) {
+        const mainDomain = parts[parts.length - 3];
+        return formatGroupName(mainDomain);
+    } else if (parts.length > 2) {
         return formatGroupName(parts.slice(-2).join('.'));
+    } else {
+        return formatGroupName(parts.join('.'));
     }
-    return formatGroupName(hostname.replace(/^www\./, ''));
 }
 
 function formatGroupName(domain) {
-    // Remove common domain extensions using a regular expression
-    const name = domain.replace(/\.(com|net|org|io|co|edu|gov|mil|biz|info|mobi|name|aero|asia|jobs|museum|tel|travel|xxx|ac|ad|ae|af|ag|ai|al|am|an|ao|aq|ar|as|at|au|aw|ax|az|ba|bb|bd|be|bf|bg|bh|bi|bj|bm|bn|bo|br|bs|bt|bv|bw|by|bz|ca|cc|cd|cf|cg|ch|ci|ck|cl|cm|cn|co|cr|cu|cv|cx|cy|cz|de|dj|dk|dm|do|dz|ec|ee|eg|er|es|et|eu|fi|fj|fk|fm|fo|fr|ga|gb|gd|ge|gf|gg|gh|gi|gl|gm|gn|gp|gq|gr|gs|gt|gu|gw|gy|hk|hm|hn|hr|ht|hu|id|ie|il|im|in|io|iq|ir|is|it|je|jm|jo|jp|ke|kg|kh|ki|km|kn|kp|kr|kw|ky|kz|la|lb|lc|li|lk|lr|ls|lt|lu|lv|ly|ma|mc|md|me|mg|mh|mk|ml|mm|mn|mo|mp|mq|mr|ms|mt|mu|mv|mw|mx|my|mz|na|nc|ne|nf|ng|ni|nl|no|np|nr|nu|nz|om|pa|pe|pf|pg|ph|pk|pl|pm|pn|pr|ps|pt|pw|py|qa|re|ro|rs|ru|rw|sa|sb|sc|sd|se|sg|sh|si|sj|sk|sl|sm|sn|so|sr|st|su|sv|sy|sz|tc|td|tf|tg|th|tj|tk|tl|tm|tn|to|tp|tr|tt|tv|tw|tz|ua|ug|uk|us|uy|uz|va|vc|ve|vg|vi|vn|vu|wf|ws|ye|yt|za|zm|zw)$/i, '');
-    
     // Capitalize the first letter
-    return name.charAt(0).toUpperCase() + name.slice(1);
+    return domain.charAt(0).toUpperCase() + domain.slice(1);
 }
 
 function getGroupColor(groupName) {

--- a/background.js
+++ b/background.js
@@ -28,7 +28,7 @@ function loadRules() {
 function genGroupName(url) {
     const { hostname } = new URL(url);
     
-    // Check user-defined rules
+    // Check user-defined rules first
     for (const rule of rules) {
         if (rule.startsWith('*.')) {
             const domain = rule.slice(2);
@@ -40,23 +40,37 @@ function genGroupName(url) {
         }
     }
 
-    const parts = hostname.split('.');
-    // Remove 'www' prefix if present
+    let parts = hostname.split('.');
+    
+    // Remove 'www' prefix
     if (parts[0] === 'www') parts.shift();
     
     // Handle country-code TLDs (e.g., .co.uk, .com.br)
-    if (parts.length >= 3 && parts[parts.length - 1].length === 2) {
-        const mainDomain = parts[parts.length - 3];
-        return formatGroupName(mainDomain);
-    } else if (parts.length > 2) {
-        return formatGroupName(parts.slice(-2).join('.'));
-    } else {
-        return formatGroupName(parts.join('.'));
+    if (parts.length >= 3 && parts[parts.length -1].length === 2) {
+        const secondLevel = parts[parts.length -2];
+        // Known country-code second-level domains
+        if (['co', 'com', 'org', 'net', 'edu', 'gov', 'mil'].includes(secondLevel)) {
+            parts = parts.slice(0, -2); // Remove TLD parts
+        } else {
+            parts = parts.slice(0, -1); // Remove country-code TLD
+        }
     }
+    
+    // Remove common TLDs
+    const COMMON_TLDS = new Set(['com', 'net', 'org', 'io', 'edu', 'gov', 'mil', 'biz', 
+                                'info', 'mobi', 'name', 'aero', 'asia', 'jobs', 'museum', 
+                                'tel', 'travel']);
+    while (parts.length > 0 && COMMON_TLDS.has(parts[parts.length -1])) {
+        parts.pop();
+    }
+    
+    // Get the main domain part
+    const mainDomain = parts.length > 0 ? parts[parts.length -1] : hostname;
+    
+    return formatGroupName(mainDomain);
 }
 
 function formatGroupName(domain) {
-    // Capitalize the first letter
     return domain.charAt(0).toUpperCase() + domain.slice(1);
 }
 


### PR DESCRIPTION
This update fixes an issue where the tab grouping feature was not correctly handling sites with country-code top-level domains (TLDs) like .co.uk and .com.br. The logic for generating group names has been improved to handle country-code TLDs by:

Removing the www prefix from domain names.
Correctly handling country-code TLDs (e.g., .co.uk, .com.br).
Removing common TLDs (e.g., .com, .net, .org, .cn etc.) from the domain name.
Ensuring the main domain is extracted for tab grouping.

- Updated `genGroupName` function to improve domain extraction.
- Removed 'www' prefix when extracting the main domain.
- Enhanced handling of country-code TLDs (e.g., `.co.uk`, `.com.br`).
- Removed common TLDs from the domain extraction process for more accurate group naming.
- Simplified group name formatting._
 
